### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/pateljinesh1990/ca675b03-2c0c-4163-950b-c6668263b2bc/a148a87b-c172-45e6-9eeb-ec5900e925fe/_apis/work/boardbadge/8dd5261c-53e4-44cf-9ada-c7f0c4b75192)](https://dev.azure.com/pateljinesh1990/ca675b03-2c0c-4163-950b-c6668263b2bc/_boards/board/t/a148a87b-c172-45e6-9eeb-ec5900e925fe/Microsoft.RequirementCategory)
 # faceDetection
 
 # My custom Domain Face app link  


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#498](https://dev.azure.com/pateljinesh1990/ca675b03-2c0c-4163-950b-c6668263b2bc/_workitems/edit/498). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.